### PR TITLE
👷 Add spellcheck steps for pull-requests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,10 @@
   // We add several additional extensions so users can work with every aspect of
   // the project.
   "extensions": [
+    "EditorConfig.EditorConfig",
+    "bierner.github-markdown-preview",
     "golang.go",
     "redhat.vscode-yaml",
-    "EditorConfig.EditorConfig",
-    "bierner.github-markdown-preview"
+    "tamasfe.even-better-toml"
   ]
 }

--- a/.github/settings/typos.toml
+++ b/.github/settings/typos.toml
@@ -1,0 +1,5 @@
+[default]
+locale = "en-us"
+
+[files]
+extend-exclude = ["go.mod", "go.sum"]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,18 @@ jobs:
       - name: Skip Duplicate Actions (Pull Request)
         uses: fkirc/skip-duplicate-actions@v3
         id: skip-check
+  spellcheck:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    needs: skip
+    if: needs.skip.outputs.should-skip != 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checking Spelling
+        uses: crate-ci/typos@v1.1.9
+        with:
+          config: ${{github.workspace}}/.github/settings/typos.toml
   actions:
     name: Lint Action Workflows
     runs-on: ubuntu-latest

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@ to wrap the entire API documented https://improvmx.com/api however not all
 features will work across all tiers. At the present time, only the v3 API is
 supported.
 
-Within this documentation, the REST API is refered to the as the ImprovMX REST
+Within this documentation, the REST API is referred to the as the ImprovMX REST
 API, and the golang API is simply called either the golang API or just "the
 API".
 


### PR DESCRIPTION
✏️ Fix typo in doc.go

This adds the wonderful typos-cli tool to our repotoire of
linting/checks for our tooling.

Additionally, we fixed a missing plugin for the devcontainer setup. At
some point we might add a TOML schema to enforce the `typos.toml` file
to be correct.
